### PR TITLE
Rework indentation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,4 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
     source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
 fi
 use flake
+export PATH=$PATH:./node_modules/.bin

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,6 +1,7 @@
 [
   (array)
   (block)
+  (lhsList)
   (CASE_opt)
   (CASE_end)
   (GuardedSTMT)

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,5 +1,6 @@
 [
   (array)
+  (block)
   (CASE_opt)
   (CASE_end)
   (GuardedSTMT)

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,12 +1,43 @@
 [
   (array)
-  (block)
-  (lhsList)
-  (CASE_opt)
-  (CASE_end)
+  ; (CASE_opt)
+  ; (CASE_end)
   (GuardedSTMT)
   (HeadedBODY)
 ] @indent
+
+(block
+  (_)
+  (CASE_end) @new_line
+  (#not-same-line? @indent @new_line)
+  (#set! "scope" "all")
+) @indent
+
+(block
+  (_)
+  (CASE_opt) @new_line
+  (#not-same-line? @indent @new_line)
+  (#set! "scope" "all")
+) @indent
+
+(GuardedSTMT
+  (STMT) @new_level
+  (#not-same-line? @indent @new_line)
+  (#set! "scope" "all")
+)
+
+(HeadedBODY
+  (BODY) @new_level
+  (#not-same-line? @indent @new_line)
+  (#set! "scope" "all")
+)
+
+; (block
+;  (CASE_end
+;    (sep) @indent)
+;  @indent)
+; @indent
+
 
 [
   "}"

--- a/test/corpus/emptylines.txt
+++ b/test/corpus/emptylines.txt
@@ -1,0 +1,81 @@
+==================
+no empty line between bodies: {𝕩 ; 𝕨+𝕩}
+==================
+{𝕩 ; 𝕨⋆𝕩}
+---
+
+(source_file
+  (STMT
+    (EXPR
+      (m2_Expr_
+        (mod_2_
+          (block
+            (CASE_opt
+              (BODY
+                (STMT
+                  (EXPR
+                    (subExpr
+                      (arg
+                        (subject
+                          (atom
+                            (specialname_s)))))))))
+            (CASE_end
+              (BODY
+                (STMT
+                  (EXPR
+                    (subExpr
+                      (arg
+                        (subject
+                          (atom
+                            (specialname_s)))
+                        (Derv
+                          (Func
+                            (symbol_Fl)))
+                        (subExpr
+                          (arg
+                            (subject
+                              (atom
+                                (specialname_s)))))))))))))))))
+
+==================
+empty line between bodies: {𝕩 ; 𝕨+𝕩}
+==================
+{𝕩 ;
+
+𝕨⋆𝕩}
+---
+
+(source_file
+  (STMT
+    (EXPR
+      (m2_Expr_
+        (mod_2_
+          (block
+            (CASE_opt
+              (BODY
+                (STMT
+                  (EXPR
+                    (subExpr
+                      (arg
+                        (subject
+                          (atom
+                            (specialname_s)))))))))
+            (CASE_end
+              (sep)
+              (BODY
+                (sep)
+                (STMT
+                  (EXPR
+                    (subExpr
+                      (arg
+                        (subject
+                          (atom
+                            (specialname_s)))
+                        (Derv
+                          (Func
+                            (symbol_Fl)))
+                        (subExpr
+                          (arg
+                            (subject
+                              (atom
+                                (specialname_s)))))))))))))))))


### PR DESCRIPTION
## Issue

- indentation for CASE_end
- handle Error ASTs
- [Helix] use `@align`
```diff
diff --git a/book/src/guides/indent.md b/book/src/guides/indent.md
index 0b0e3938..bd037bb0 100644
--- a/book/src/guides/indent.md
+++ b/book/src/guides/indent.md
@@ -71,6 +71,12 @@ ### Capture types
 ignored.
- `@outdent.always` (default scope `all`):
 Decrease the indent level by 1. The same rules as for `@indent.always` apply.
+- `@align` (default scope `all`):
+  Align everything inside this node to some anchor. The anchor is given
+  by the start of the node captured by `@anchor` in the same pattern.
+  Every pattern with an `@align` should contain exactly one `@anchor`.
+  Indent (and outdent) for nodes below (in terms of their starting line)
+  the `@align` node is added to the indentation required for alignment.
- `@extend`:
 Extend the range of this node to the end of the line and to lines that are
 indented more than the line that this node starts on. This is useful for
```

## senario 1
- [![asciicast](https://asciinema.org/a/600728.svg)](https://asciinema.org/a/600728)
```apl
F ← {
  𝕊 x :
    0 𝕊 x ;
  w 𝕊 x :
    w+x⊑⟨
      1
      3
    ⟩
}
```

# candidate


- https://asciinema.org/a/600730
```
(array) @indent
(block (_)* @indent)
(HeadedBODY (BODY) @indent)

[
  "}"
  "]"
  "⟩"
  ")"
] @outdent
```


```
[
  (CASE_opt)
  (CASE_end)
] @indent

[
  "}"
  "]"
  "⟩"
] @outdent

(HeadedBODY (_) @indent) @indent
```

[![asciicast](https://asciinema.org/a/604785.svg)](https://asciinema.org/a/604785)